### PR TITLE
Bump version to 0.13.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,9 @@ jobs:
       - checkout
       - run:
           name: Install modules and dependencies.
-          command: npm install
+          command: |
+            npm install
+            npm link
       - run:
           name: Link the module being tested to the samples.
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,8 +122,8 @@ jobs:
           name: Link the module being tested to the samples.
           command: |
             cd samples/
-            npm install
             npm link @google-cloud/language
+            npm install
             cd ..
       - run:
           name: Run linting.
@@ -161,8 +161,8 @@ jobs:
           name: Link the module being tested to the samples.
           command: |
             cd samples/
-            npm install
             npm link @google-cloud/language
+            npm install
             cd ..
       - run:
           name: Run sample tests.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/language",
   "description": "Google Cloud Natural Language API client for Node.js",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "license": "Apache-2.0",
   "author": "Google Inc",
   "engines": {

--- a/samples/package.json
+++ b/samples/package.json
@@ -19,7 +19,7 @@
     "test": "repo-tools test run --cmd npm -- run cover"
   },
   "dependencies": {
-    "@google-cloud/language": "0.12.1",
+    "@google-cloud/language": "0.13.0",
     "@google-cloud/storage": "1.4.0",
     "yargs": "9.0.1"
   },


### PR DESCRIPTION
## :warning: Breaking Changes!

#### New client class

The client object is no longer initialized with `require('@google-cloud/language').v1()`. This used to return a function that built and returned an internal class.

We now expose an ES6 class directly; there are no wrappers or obfuscation. Basic usage looks like this:

```es6
// Import the language module.
const language = require('@google-cloud/language');

// Instantiate a client class.
let client = new language.LanguageServiceClient();
```

As before, there are two backend versions (spelled `v1` and `v1beta2`) included. You get the latest GA (`v1`) by default, but you can pin to a specific backend version:

```es6
// Import a specific backend version of the language module.
const language = require('@google-cloud/language').v1;  // or .v1beta2;
```

## Implementation Details

  * Add runnable samples in `samples/` directory.
  * Change to a new linter (ESLint) and code style formatter (prettify).
  * Update docs to use [JSDoc 3](https://usejsdoc.org/).
  * Migrate to the `googleapis/nodejs-language` repository.