### PR TITLE
Add the `classifyText` method to language (v1).

### DIFF
--- a/protos/google/cloud/language/v1/language_service.proto
+++ b/protos/google/cloud/language/v1/language_service.proto
@@ -52,6 +52,11 @@ service LanguageService {
     option (google.api.http) = { post: "/v1/documents:analyzeSyntax" body: "*" };
   }
 
+  // Classifies a document into categories.
+  rpc ClassifyText(ClassifyTextRequest) returns (ClassifyTextResponse) {
+    option (google.api.http) = { post: "/v1/documents:classifyText" body: "*" };
+  }
+
   // A convenience method that provides all the features that analyzeSentiment,
   // analyzeEntities, and analyzeSyntax provide in one call.
   rpc AnnotateText(AnnotateTextRequest) returns (AnnotateTextResponse) {
@@ -839,6 +844,16 @@ message TextSpan {
   int32 begin_offset = 2;
 }
 
+// Represents a category returned from the text classifier.
+message ClassificationCategory {
+  // The name of the category representing the document.
+  string name = 1;
+
+  // The classifier's confidence of the category. Number represents how certain
+  // the classifier is that this category represents the given text.
+  float confidence = 2;
+}
+
 // The sentiment analysis request message.
 message AnalyzeSentimentRequest {
   // Input document.
@@ -925,6 +940,18 @@ message AnalyzeSyntaxResponse {
   string language = 3;
 }
 
+// The document classification request message.
+message ClassifyTextRequest {
+  // Input document.
+  Document document = 1;
+}
+
+// The document classification response message.
+message ClassifyTextResponse {
+  // Categories representing the input document.
+  repeated ClassificationCategory categories = 1;
+}
+
 // The request message for the text annotation API, which can perform multiple
 // analysis types (sentiment, entities, and syntax) in one call.
 message AnnotateTextRequest {
@@ -942,6 +969,9 @@ message AnnotateTextRequest {
 
     // Extract entities and their associated sentiment.
     bool extract_entity_sentiment = 4;
+
+    // Classify the full document into categories.
+    bool classify_text = 6;
   }
 
   // Input document.
@@ -978,6 +1008,9 @@ message AnnotateTextResponse {
   // in the request or, if not specified, the automatically-detected language.
   // See [Document.language][google.cloud.language.v1.Document.language] field for more details.
   string language = 5;
+
+  // Categories identified in the input document.
+  repeated ClassificationCategory categories = 6;
 }
 
 // Represents the text encoding that the caller uses to process the output.

--- a/samples/analyze.v1.js
+++ b/samples/analyze.v1.js
@@ -18,11 +18,10 @@
 function analyzeSentimentOfText(text) {
   // [START language_sentiment_string]
   // Imports the Google Cloud client library
-  const LanguageServiceClient = require('@google-cloud/language')
-    .LanguageServiceClient;
+  const language = require('@google-cloud/language');
 
   // Creates a client
-  const language = new LanguageServiceClient();
+  const client = new language.LanguageServiceClient();
 
   /**
    * TODO(developer): Uncomment the following line to run this code.
@@ -36,7 +35,7 @@ function analyzeSentimentOfText(text) {
   };
 
   // Detects the sentiment of the document
-  language
+  client
     .analyzeSentiment({document: document})
     .then(results => {
       const sentiment = results[0].documentSentiment;
@@ -60,11 +59,10 @@ function analyzeSentimentOfText(text) {
 function analyzeSentimentInFile(bucketName, fileName) {
   // [START language_sentiment_file]
   // Imports the Google Cloud client library
-  const LanguageServiceClient = require('@google-cloud/language')
-    .LanguageServiceClient;
+  const language = require('@google-cloud/language');
 
   // Creates a client
-  const language = new LanguageServiceClient();
+  const client = new language.LanguageServiceClient();
 
   /**
    * TODO(developer): Uncomment the following lines to run this code
@@ -79,7 +77,7 @@ function analyzeSentimentInFile(bucketName, fileName) {
   };
 
   // Detects the sentiment of the document
-  language
+  client
     .analyzeSentiment({document: document})
     .then(results => {
       const sentiment = results[0].documentSentiment;
@@ -103,11 +101,10 @@ function analyzeSentimentInFile(bucketName, fileName) {
 function analyzeEntitiesOfText(text) {
   // [START language_entities_string]
   // Imports the Google Cloud client library
-  const LanguageServiceClient = require('@google-cloud/language')
-    .LanguageServiceClient;
+  const language = require('@google-cloud/language');
 
   // Creates a client
-  const language = new LanguageServiceClient();
+  const client = new language.LanguageServiceClient();
 
   /**
    * TODO(developer): Uncomment the following line to run this code.
@@ -121,7 +118,7 @@ function analyzeEntitiesOfText(text) {
   };
 
   // Detects entities in the document
-  language
+  client
     .analyzeEntities({document: document})
     .then(results => {
       const entities = results[0].entities;
@@ -144,11 +141,10 @@ function analyzeEntitiesOfText(text) {
 function analyzeEntitiesInFile(bucketName, fileName) {
   // [START language_entities_file]
   // Imports the Google Cloud client library
-  const LanguageServiceClient = require('@google-cloud/language')
-    .LanguageServiceClient;
+  const language = require('@google-cloud/language');
 
   // Creates a client
-  const language = new LanguageServiceClient();
+  const client = new language.LanguageServiceClient();
 
   /**
    * TODO(developer): Uncomment the following lines to run this code
@@ -163,7 +159,7 @@ function analyzeEntitiesInFile(bucketName, fileName) {
   };
 
   // Detects entities in the document
-  language
+  client
     .analyzeEntities({document: document})
     .then(results => {
       const entities = results[0].entities;
@@ -186,11 +182,10 @@ function analyzeEntitiesInFile(bucketName, fileName) {
 function analyzeSyntaxOfText(text) {
   // [START language_syntax_string]
   // Imports the Google Cloud client library
-  const LanguageServiceClient = require('@google-cloud/language')
-    .LanguageServiceClient;
+  const language = require('@google-cloud/language');
 
   // Creates a client
-  const language = new LanguageServiceClient();
+  const client = new language.LanguageServiceClient();
 
   /**
    * TODO(developer): Uncomment the following line to run this code.
@@ -204,7 +199,7 @@ function analyzeSyntaxOfText(text) {
   };
 
   // Detects syntax in the document
-  language
+  client
     .analyzeSyntax({document: document})
     .then(results => {
       const syntax = results[0];
@@ -224,11 +219,10 @@ function analyzeSyntaxOfText(text) {
 function analyzeSyntaxInFile(bucketName, fileName) {
   // [START language_syntax_file]
   // Imports the Google Cloud client library
-  const LanguageServiceClient = require('@google-cloud/language')
-    .LanguageServiceClient;
+  const language = require('@google-cloud/language');
 
   // Creates a client
-  const language = new LanguageServiceClient();
+  const client = new language.LanguageServiceClient();
 
   /**
    * TODO(developer): Uncomment the following lines to run this code
@@ -243,7 +237,7 @@ function analyzeSyntaxInFile(bucketName, fileName) {
   };
 
   // Detects syntax in the document
-  language
+  client
     .analyzeSyntax({document: document})
     .then(results => {
       const syntax = results[0];
@@ -263,11 +257,10 @@ function analyzeSyntaxInFile(bucketName, fileName) {
 function analyzeEntitySentimentOfText(text) {
   // [START language_entity_sentiment_string]
   // Imports the Google Cloud client library
-  const LanguageServiceClient = require('@google-cloud/language')
-    .LanguageServiceClient;
+  const language = require('@google-cloud/language');
 
   // Creates a client
-  const language = new LanguageServiceClient();
+  const client = new language.LanguageServiceClient();
 
   /**
    * TODO(developer): Uncomment the following line to run this code.
@@ -281,7 +274,7 @@ function analyzeEntitySentimentOfText(text) {
   };
 
   // Detects sentiment of entities in the document
-  language
+  client
     .analyzeEntitySentiment({document: document})
     .then(results => {
       const entities = results[0].entities;
@@ -303,11 +296,10 @@ function analyzeEntitySentimentOfText(text) {
 function analyzeEntitySentimentInFile(bucketName, fileName) {
   // [START language_entity_sentiment_file]
   // Imports the Google Cloud client library
-  const LanguageServiceClient = require('@google-cloud/language')
-    .LanguageServiceClient;
+  const language = require('@google-cloud/language');
 
   // Creates a client
-  const language = new LanguageServiceClient();
+  const client = new language.LanguageServiceClient();
 
   /**
    * TODO(developer): Uncomment the following lines to run this code
@@ -322,7 +314,7 @@ function analyzeEntitySentimentInFile(bucketName, fileName) {
   };
 
   // Detects sentiment of entities in the document
-  language
+  client
     .analyzeEntitySentiment({document: document})
     .then(results => {
       const entities = results[0].entities;
@@ -339,6 +331,83 @@ function analyzeEntitySentimentInFile(bucketName, fileName) {
       console.error('ERROR:', err);
     });
   // [END language_entity_sentiment_file]
+}
+
+function classifyTextOfText(text) {
+  // [START language_classify_string]
+  // Imports the Google Cloud client library
+  const language = require('@google-cloud/language');
+
+  // Creates a client
+  const client = new language.LanguageServiceClient();
+
+  /**
+   * TODO(developer): Uncomment the following line to run this code.
+   */
+  // const text = 'Your text to analyze, e.g. Hello, world!';
+
+  // Prepares a document, representing the provided text
+  const document = {
+    content: text,
+    type: 'PLAIN_TEXT',
+  };
+
+  // Classifies text in the document
+  client
+    .classifyText({document: document})
+    .then(results => {
+      const classification = results[0];
+
+      console.log('Categories:');
+      classification.categories.forEach(category => {
+        console.log(
+          `Name: ${category.name}, Confidence: ${category.confidence}`
+        );
+      });
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
+  // [END language_classify_string]
+}
+
+function classifyTextInFile(bucketName, fileName) {
+  // [START language_classify_file]
+  // Imports the Google Cloud client library.
+  const language = require('@google-cloud/language');
+
+  // Creates a client.
+  const client = new language.LanguageServiceClient();
+
+  /**
+   * TODO(developer): Uncomment the following lines to run this code
+   */
+  // const bucketName = 'Your bucket name, e.g. my-bucket';
+  // const fileName = 'Your file name, e.g. my-file.txt';
+
+  // Prepares a document, representing a text file in Cloud Storage
+  const document = {
+    gcsContentUri: `gs://${bucketName}/${fileName}`,
+    type: 'PLAIN_TEXT',
+  };
+
+  // Classifies text in the document
+  client
+    .classifyText({document: document})
+    .then(results => {
+      const classification = results[0];
+
+      console.log('Categories:');
+      classification.categories.forEach(category => {
+        console.log(
+          `Name: ${category.name}, Confidence: ${category.confidence}`
+        );
+      });
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    });
+  // [END language_classify_file]
 }
 
 require(`yargs`)
@@ -385,6 +454,15 @@ require(`yargs`)
     {},
     opts => analyzeEntitySentimentInFile(opts.bucketName, opts.fileName)
   )
+  .command(`classify-text <text>`, `Classifies text of a string.`, {}, opts =>
+    classifyTextOfText(opts.text)
+  )
+  .command(
+    `classify-file <bucketName> <fileName>`,
+    `Classifies text in a file in Google Cloud Storage.`,
+    {},
+    opts => classifyTextInFile(opts.bucketName, opts.fileName)
+  )
   .example(
     `node $0 sentiment-text "President Obama is speaking at the White House."`
   )
@@ -412,6 +490,13 @@ require(`yargs`)
   .example(
     `node $0 entity-sentiment-file my-bucket file.txt`,
     `Detects sentiment of entities in gs://my-bucket/file.txt`
+  )
+  .example(
+    `node $0 classify-text "Android is a mobile operating system developed by Google."`
+  )
+  .example(
+    `node $0 classify-file my-bucket android_text.txt`,
+    `Detects syntax in gs://my-bucket/android_text.txt`
   )
   .wrap(120)
   .recommendCommands()

--- a/samples/analyze.v1beta2.js
+++ b/samples/analyze.v1beta2.js
@@ -18,11 +18,10 @@
 function analyzeSentimentOfText(text) {
   // [START language_sentiment_string]
   // Imports the Google Cloud client library
-  const LanguageServiceClient = require('@google-cloud/language').v1beta2
-    .LanguageServiceClient;
+  const language = require('@google-cloud/language').v1beta2;
 
   // Creates a v1beta2 client
-  const language = new LanguageServiceClient();
+  const client = new language.LanguageServiceClient();
 
   /**
    * TODO(developer): Uncomment the following line to run this code.
@@ -36,7 +35,7 @@ function analyzeSentimentOfText(text) {
   };
 
   // Detects the sentiment of the document
-  language
+  client
     .analyzeSentiment({document: document})
     .then(results => {
       const sentiment = results[0].documentSentiment;
@@ -60,11 +59,10 @@ function analyzeSentimentOfText(text) {
 function analyzeSentimentInFile(bucketName, fileName) {
   // [START language_sentiment_file]
   // Imports the Google Cloud client library
-  const LanguageServiceClient = require('@google-cloud/language').v1beta2
-    .LanguageServiceClient;
+  const language = require('@google-cloud/language').v1beta2;
 
   // Creates a v1beta2 client
-  const language = new LanguageServiceClient();
+  const client = new language.LanguageServiceClient();
 
   /**
    * TODO(developer): Uncomment the following lines to run this code
@@ -79,7 +77,7 @@ function analyzeSentimentInFile(bucketName, fileName) {
   };
 
   // Detects the sentiment of the document
-  language
+  client
     .analyzeSentiment({document: document})
     .then(results => {
       const sentiment = results[0].documentSentiment;
@@ -103,11 +101,10 @@ function analyzeSentimentInFile(bucketName, fileName) {
 function analyzeEntitiesOfText(text) {
   // [START language_entities_string]
   // Imports the Google Cloud client library
-  const LanguageServiceClient = require('@google-cloud/language').v1beta2
-    .LanguageServiceClient;
+  const language = require('@google-cloud/language').v1beta2;
 
   // Creates a v1beta2 client
-  const language = new LanguageServiceClient();
+  const client = new language.LanguageServiceClient();
 
   /**
    * TODO(developer): Uncomment the following line to run this code.
@@ -121,7 +118,7 @@ function analyzeEntitiesOfText(text) {
   };
 
   // Detects entities in the document
-  language
+  client
     .analyzeEntities({document: document})
     .then(results => {
       const entities = results[0].entities;
@@ -144,11 +141,10 @@ function analyzeEntitiesOfText(text) {
 function analyzeEntitiesInFile(bucketName, fileName) {
   // [START language_entities_file]
   // Imports the Google Cloud client library
-  const LanguageServiceClient = require('@google-cloud/language').v1beta2
-    .LanguageServiceClient;
+  const language = require('@google-cloud/language').v1beta2;
 
   // Creates a v1beta2 client
-  const language = new LanguageServiceClient();
+  const client = new language.LanguageServiceClient();
 
   /**
    * TODO(developer): Uncomment the following lines to run this code
@@ -163,7 +159,7 @@ function analyzeEntitiesInFile(bucketName, fileName) {
   };
 
   // Detects entities in the document
-  language
+  client
     .analyzeEntities({document: document})
     .then(results => {
       const entities = results[0].entities;
@@ -186,11 +182,10 @@ function analyzeEntitiesInFile(bucketName, fileName) {
 function analyzeSyntaxOfText(text) {
   // [START language_syntax_string]
   // Imports the Google Cloud client library
-  const LanguageServiceClient = require('@google-cloud/language').v1beta2
-    .LanguageServiceClient;
+  const language = require('@google-cloud/language').v1beta2;
 
   // Creates a v1beta2 client
-  const language = new LanguageServiceClient();
+  const client = new language.LanguageServiceClient();
 
   /**
    * TODO(developer): Uncomment the following line to run this code.
@@ -204,7 +199,7 @@ function analyzeSyntaxOfText(text) {
   };
 
   // Detects syntax in the document
-  language
+  client
     .analyzeSyntax({document: document})
     .then(results => {
       const syntax = results[0];
@@ -224,11 +219,10 @@ function analyzeSyntaxOfText(text) {
 function analyzeSyntaxInFile(bucketName, fileName) {
   // [START language_syntax_file]
   // Imports the Google Cloud client library
-  const LanguageServiceClient = require('@google-cloud/language').v1beta2
-    .LanguageServiceClient;
+  const language = require('@google-cloud/language').v1beta2;
 
   // Creates a v1beta2 client
-  const language = new LanguageServiceClient();
+  const client = new language.LanguageServiceClient();
 
   /**
    * TODO(developer): Uncomment the following lines to run this code
@@ -243,7 +237,7 @@ function analyzeSyntaxInFile(bucketName, fileName) {
   };
 
   // Detects syntax in the document
-  language
+  client
     .analyzeSyntax({document: document})
     .then(results => {
       const syntax = results[0];
@@ -263,11 +257,10 @@ function analyzeSyntaxInFile(bucketName, fileName) {
 function classifyTextOfText(text) {
   // [START language_classify_string]
   // Imports the Google Cloud client library
-  const LanguageServiceClient = require('@google-cloud/language').v1beta2
-    .LanguageServiceClient;
+  const language = require('@google-cloud/language').v1beta2;
 
   // Creates a v1beta2 client
-  const language = new LanguageServiceClient();
+  const client = new language.LanguageServiceClient();
 
   /**
    * TODO(developer): Uncomment the following line to run this code.
@@ -281,7 +274,7 @@ function classifyTextOfText(text) {
   };
 
   // Classifies text in the document
-  language
+  client
     .classifyText({document: document})
     .then(results => {
       const classification = results[0];
@@ -302,11 +295,10 @@ function classifyTextOfText(text) {
 function classifyTextInFile(bucketName, fileName) {
   // [START language_classify_file]
   // Imports the Google Cloud client library
-  const LanguageServiceClient = require('@google-cloud/language').v1beta2
-    .LanguageServiceClient;
+  const language = require('@google-cloud/language').v1beta2;
 
   // Creates a v1beta2 client
-  const language = new LanguageServiceClient();
+  const client = new language.LanguageServiceClient();
 
   /**
    * TODO(developer): Uncomment the following lines to run this code
@@ -321,7 +313,7 @@ function classifyTextInFile(bucketName, fileName) {
   };
 
   // Classifies text in the document
-  language
+  client
     .classifyText({document: document})
     .then(results => {
       const classification = results[0];

--- a/src/v1/doc/google/cloud/language/v1/doc_language_service.js
+++ b/src/v1/doc/google/cloud/language/v1/doc_language_service.js
@@ -1368,6 +1368,24 @@ var TextSpan = {
 };
 
 /**
+ * Represents a category returned from the text classifier.
+ *
+ * @property {string} name
+ *   The name of the category representing the document.
+ *
+ * @property {number} confidence
+ *   The classifier's confidence of the category. Number represents how certain
+ *   the classifier is that this category represents the given text.
+ *
+ * @typedef ClassificationCategory
+ * @memberof google.cloud.language.v1
+ * @see [google.cloud.language.v1.ClassificationCategory definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/language/v1/language_service.proto}
+ */
+var ClassificationCategory = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
  * The sentiment analysis request message.
  *
  * @property {Object} document
@@ -1546,6 +1564,38 @@ var AnalyzeSyntaxResponse = {
 };
 
 /**
+ * The document classification request message.
+ *
+ * @property {Object} document
+ *   Input document.
+ *
+ *   This object should have the same structure as [Document]{@link google.cloud.language.v1.Document}
+ *
+ * @typedef ClassifyTextRequest
+ * @memberof google.cloud.language.v1
+ * @see [google.cloud.language.v1.ClassifyTextRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/language/v1/language_service.proto}
+ */
+var ClassifyTextRequest = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * The document classification response message.
+ *
+ * @property {Object[]} categories
+ *   Categories representing the input document.
+ *
+ *   This object should have the same structure as [ClassificationCategory]{@link google.cloud.language.v1.ClassificationCategory}
+ *
+ * @typedef ClassifyTextResponse
+ * @memberof google.cloud.language.v1
+ * @see [google.cloud.language.v1.ClassifyTextResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/language/v1/language_service.proto}
+ */
+var ClassifyTextResponse = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
  * The request message for the text annotation API, which can perform multiple
  * analysis types (sentiment, entities, and syntax) in one call.
  *
@@ -1586,6 +1636,9 @@ var AnnotateTextRequest = {
    *
    * @property {boolean} extractEntitySentiment
    *   Extract entities and their associated sentiment.
+   *
+   * @property {boolean} classifyText
+   *   Classify the full document into categories.
    *
    * @typedef Features
    * @memberof google.cloud.language.v1
@@ -1629,6 +1682,11 @@ var AnnotateTextRequest = {
  *   The language of the text, which will be the same as the language specified
  *   in the request or, if not specified, the automatically-detected language.
  *   See Document.language field for more details.
+ *
+ * @property {Object[]} categories
+ *   Categories identified in the input document.
+ *
+ *   This object should have the same structure as [ClassificationCategory]{@link google.cloud.language.v1.ClassificationCategory}
  *
  * @typedef AnnotateTextResponse
  * @memberof google.cloud.language.v1

--- a/src/v1/language_service_client.js
+++ b/src/v1/language_service_client.js
@@ -32,28 +32,28 @@ class LanguageServiceClient {
   /**
    * Construct an instance of LanguageServiceClient.
    *
-   * @param {object=} options - The configuration object. See the subsequent
+   * @param {object} [options] - The configuration object. See the subsequent
    *   parameters for more details.
-   * @param {object=} options.credentials - Credentials object.
-   * @param {string=} options.credentials.client_email
-   * @param {string=} options.credentials.private_key
-   * @param {string=} options.email - Account email address. Required when
+   * @param {object} [options.credentials] - Credentials object.
+   * @param {string} [options.credentials.client_email]
+   * @param {string} [options.credentials.private_key]
+   * @param {string} [options.email] - Account email address. Required when
    *   usaing a .pem or .p12 keyFilename.
-   * @param {string=} options.keyFilename - Full path to the a .json, .pem, or
+   * @param {string} [options.keyFilename] - Full path to the a .json, .pem, or
    *     .p12 key downloaded from the Google Developers Console. If you provide
    *     a path to a JSON file, the projectId option above is not necessary.
    *     NOTE: .pem and .p12 require you to specify options.email as well.
-   * @param {number=} options.port - The port on which to connect to
+   * @param {number} [options.port] - The port on which to connect to
    *     the remote host.
-   * @param {string=} options.projectId - The project ID from the Google
+   * @param {string} [options.projectId] - The project ID from the Google
    *     Developer's Console, e.g. 'grape-spaceship-123'. We will also check
    *     the environment variable GCLOUD_PROJECT for your project ID. If your
    *     app is running in an environment which supports
    *     {@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
    *     your project ID will be detected automatically.
-   * @param {function=} options.promise - Custom promise module to use instead
+   * @param {function} [options.promise] - Custom promise module to use instead
    *     of native Promises.
-   * @param {string=} options.servicePath - The domain name of the
+   * @param {string} [options.servicePath] - The domain name of the
    *     API remote host.
    */
   constructor(opts) {
@@ -124,6 +124,7 @@ class LanguageServiceClient {
       'analyzeEntities',
       'analyzeEntitySentiment',
       'analyzeSyntax',
+      'classifyText',
       'annotateText',
     ];
     for (let methodName of languageServiceStubMethods) {
@@ -185,14 +186,14 @@ class LanguageServiceClient {
    *   Input document.
    *
    *   This object should have the same structure as [Document]{@link google.cloud.language.v1.Document}
-   * @param {number=} request.encodingType
+   * @param {number} [request.encodingType]
    *   The encoding type used by the API to calculate sentence offsets.
    *
    *   The number should be among the values of [EncodingType]{@link google.cloud.language.v1.EncodingType}
-   * @param {Object=} options
+   * @param {Object} [options]
    *   Optional parameters. You can override the default settings for this call, e.g, timeout,
    *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
-   * @param {function(?Error, ?Object)=} callback
+   * @param {function(?Error, ?Object)} [callback]
    *   The function which will be called with the result of the API call.
    *
    *   The second parameter to the callback is an object representing [AnalyzeSentimentResponse]{@link google.cloud.language.v1.AnalyzeSentimentResponse}.
@@ -239,14 +240,14 @@ class LanguageServiceClient {
    *   Input document.
    *
    *   This object should have the same structure as [Document]{@link google.cloud.language.v1.Document}
-   * @param {number=} request.encodingType
+   * @param {number} [request.encodingType]
    *   The encoding type used by the API to calculate offsets.
    *
    *   The number should be among the values of [EncodingType]{@link google.cloud.language.v1.EncodingType}
-   * @param {Object=} options
+   * @param {Object} [options]
    *   Optional parameters. You can override the default settings for this call, e.g, timeout,
    *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
-   * @param {function(?Error, ?Object)=} callback
+   * @param {function(?Error, ?Object)} [callback]
    *   The function which will be called with the result of the API call.
    *
    *   The second parameter to the callback is an object representing [AnalyzeEntitiesResponse]{@link google.cloud.language.v1.AnalyzeEntitiesResponse}.
@@ -292,14 +293,14 @@ class LanguageServiceClient {
    *   Input document.
    *
    *   This object should have the same structure as [Document]{@link google.cloud.language.v1.Document}
-   * @param {number=} request.encodingType
+   * @param {number} [request.encodingType]
    *   The encoding type used by the API to calculate offsets.
    *
    *   The number should be among the values of [EncodingType]{@link google.cloud.language.v1.EncodingType}
-   * @param {Object=} options
+   * @param {Object} [options]
    *   Optional parameters. You can override the default settings for this call, e.g, timeout,
    *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
-   * @param {function(?Error, ?Object)=} callback
+   * @param {function(?Error, ?Object)} [callback]
    *   The function which will be called with the result of the API call.
    *
    *   The second parameter to the callback is an object representing [AnalyzeEntitySentimentResponse]{@link google.cloud.language.v1.AnalyzeEntitySentimentResponse}.
@@ -350,14 +351,14 @@ class LanguageServiceClient {
    *   Input document.
    *
    *   This object should have the same structure as [Document]{@link google.cloud.language.v1.Document}
-   * @param {number=} request.encodingType
+   * @param {number} [request.encodingType]
    *   The encoding type used by the API to calculate offsets.
    *
    *   The number should be among the values of [EncodingType]{@link google.cloud.language.v1.EncodingType}
-   * @param {Object=} options
+   * @param {Object} [options]
    *   Optional parameters. You can override the default settings for this call, e.g, timeout,
    *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
-   * @param {function(?Error, ?Object)=} callback
+   * @param {function(?Error, ?Object)} [callback]
    *   The function which will be called with the result of the API call.
    *
    *   The second parameter to the callback is an object representing [AnalyzeSyntaxResponse]{@link google.cloud.language.v1.AnalyzeSyntaxResponse}.
@@ -394,6 +395,54 @@ class LanguageServiceClient {
   }
 
   /**
+   * Classifies a document into categories.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {Object} request.document
+   *   Input document.
+   *
+   *   This object should have the same structure as [Document]{@link google.cloud.language.v1.Document}
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)} [callback]
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [ClassifyTextResponse]{@link google.cloud.language.v1.ClassifyTextResponse}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [ClassifyTextResponse]{@link google.cloud.language.v1.ClassifyTextResponse}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * const language = require('@google-cloud/language');
+   *
+   * var client = new language.v1.LanguageServiceClient({
+   *   // optional auth parameters.
+   * });
+   *
+   * var document = {};
+   * client.classifyText({document: document})
+   *   .then(responses => {
+   *     var response = responses[0];
+   *     // doThingsWith(response)
+   *   })
+   *   .catch(err => {
+   *     console.error(err);
+   *   });
+   */
+  classifyText(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.classifyText(request, options, callback);
+  }
+
+  /**
    * A convenience method that provides all the features that analyzeSentiment,
    * analyzeEntities, and analyzeSyntax provide in one call.
    *
@@ -407,14 +456,14 @@ class LanguageServiceClient {
    *   The enabled features.
    *
    *   This object should have the same structure as [Features]{@link google.cloud.language.v1.Features}
-   * @param {number=} request.encodingType
+   * @param {number} [request.encodingType]
    *   The encoding type used by the API to calculate offsets.
    *
    *   The number should be among the values of [EncodingType]{@link google.cloud.language.v1.EncodingType}
-   * @param {Object=} options
+   * @param {Object} [options]
    *   Optional parameters. You can override the default settings for this call, e.g, timeout,
    *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
-   * @param {function(?Error, ?Object)=} callback
+   * @param {function(?Error, ?Object)} [callback]
    *   The function which will be called with the result of the API call.
    *
    *   The second parameter to the callback is an object representing [AnnotateTextResponse]{@link google.cloud.language.v1.AnnotateTextResponse}.

--- a/src/v1/language_service_client_config.json
+++ b/src/v1/language_service_client_config.json
@@ -40,6 +40,11 @@
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
+        "ClassifyText": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
         "AnnotateText": {
           "timeout_millis": 30000,
           "retry_codes_name": "idempotent",

--- a/test/gapic-v1.js
+++ b/test/gapic-v1.js
@@ -25,7 +25,10 @@ error.code = FAKE_STATUS_CODE;
 describe('LanguageServiceClient', () => {
   describe('analyzeSentiment', () => {
     it('invokes analyzeSentiment without error', done => {
-      var client = new languageModule.v1.LanguageServiceClient();
+      var client = new languageModule.v1.LanguageServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var document = {};
@@ -53,7 +56,10 @@ describe('LanguageServiceClient', () => {
     });
 
     it('invokes analyzeSentiment with error', done => {
-      var client = new languageModule.v1.LanguageServiceClient();
+      var client = new languageModule.v1.LanguageServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var document = {};
@@ -79,7 +85,10 @@ describe('LanguageServiceClient', () => {
 
   describe('analyzeEntities', () => {
     it('invokes analyzeEntities without error', done => {
-      var client = new languageModule.v1.LanguageServiceClient();
+      var client = new languageModule.v1.LanguageServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var document = {};
@@ -107,7 +116,10 @@ describe('LanguageServiceClient', () => {
     });
 
     it('invokes analyzeEntities with error', done => {
-      var client = new languageModule.v1.LanguageServiceClient();
+      var client = new languageModule.v1.LanguageServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var document = {};
@@ -133,7 +145,10 @@ describe('LanguageServiceClient', () => {
 
   describe('analyzeEntitySentiment', () => {
     it('invokes analyzeEntitySentiment without error', done => {
-      var client = new languageModule.v1.LanguageServiceClient();
+      var client = new languageModule.v1.LanguageServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var document = {};
@@ -161,7 +176,10 @@ describe('LanguageServiceClient', () => {
     });
 
     it('invokes analyzeEntitySentiment with error', done => {
-      var client = new languageModule.v1.LanguageServiceClient();
+      var client = new languageModule.v1.LanguageServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var document = {};
@@ -187,7 +205,10 @@ describe('LanguageServiceClient', () => {
 
   describe('analyzeSyntax', () => {
     it('invokes analyzeSyntax without error', done => {
-      var client = new languageModule.v1.LanguageServiceClient();
+      var client = new languageModule.v1.LanguageServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var document = {};
@@ -215,7 +236,10 @@ describe('LanguageServiceClient', () => {
     });
 
     it('invokes analyzeSyntax with error', done => {
-      var client = new languageModule.v1.LanguageServiceClient();
+      var client = new languageModule.v1.LanguageServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var document = {};
@@ -239,9 +263,69 @@ describe('LanguageServiceClient', () => {
     });
   });
 
+  describe('classifyText', () => {
+    it('invokes classifyText without error', done => {
+      var client = new languageModule.v1.LanguageServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var document = {};
+      var request = {
+        document: document,
+      };
+
+      // Mock response
+      var expectedResponse = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.classifyText = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.classifyText(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes classifyText with error', done => {
+      var client = new languageModule.v1.LanguageServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var document = {};
+      var request = {
+        document: document,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.classifyText = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.classifyText(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
   describe('annotateText', () => {
     it('invokes annotateText without error', done => {
-      var client = new languageModule.v1.LanguageServiceClient();
+      var client = new languageModule.v1.LanguageServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var document = {};
@@ -271,7 +355,10 @@ describe('LanguageServiceClient', () => {
     });
 
     it('invokes annotateText with error', done => {
-      var client = new languageModule.v1.LanguageServiceClient();
+      var client = new languageModule.v1.LanguageServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var document = {};


### PR DESCRIPTION
This PR adds the `classifyText` method currently in the `v1beta2` API version to the `v1` version. This should be held until November 15 (the endpoint will not be live on `v1` until then) but samples should be updated here.