### PR TITLE
fix: adds encodingType to analyzeSyntax* sampless

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ system-test/*key.json
 .DS_Store
 package-lock.json
 __pycache__
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ system-test/*key.json
 package-lock.json
 __pycache__
 .vscode
+*.code-workspace

--- a/samples/analyze.v1.js
+++ b/samples/analyze.v1.js
@@ -184,7 +184,7 @@ async function analyzeSyntaxOfText(text) {
   const encodingType = 'UTF-8';
 
   // Detects the sentiment of the document
-  const [syntax] = await client.analyzeSentiment({document, encodingType});
+  const [syntax] = await client.analyzeSyntax({document, encodingType});
 
   console.log('Tokens:');
   syntax.tokens.forEach(part => {
@@ -218,7 +218,7 @@ async function analyzeSyntaxInFile(bucketName, fileName) {
   const encodingType = 'UTF-8';
 
   // Detects the sentiment of the document
-  const [syntax] = await client.analyzeSentiment({document, encodingType});
+  const [syntax] = await client.analyzeSyntax({document, encodingType});
 
   console.log('Parts of speech:');
   syntax.tokens.forEach(part => {

--- a/samples/analyze.v1.js
+++ b/samples/analyze.v1.js
@@ -181,7 +181,7 @@ async function analyzeSyntaxOfText(text) {
   };
 
   // Need to specify an encodingType to receive word offsets
-  const encodingType = 'UTF-8';
+  const encodingType = 'UTF8';
 
   // Detects the sentiment of the document
   const [syntax] = await client.analyzeSyntax({document, encodingType});
@@ -215,7 +215,7 @@ async function analyzeSyntaxInFile(bucketName, fileName) {
   };
 
   // Need to specify an encodingType to receive word offsets
-  const encodingType = 'UTF-8';
+  const encodingType = 'UTF8';
 
   // Detects the sentiment of the document
   const [syntax] = await client.analyzeSyntax({document, encodingType});

--- a/samples/analyze.v1.js
+++ b/samples/analyze.v1.js
@@ -180,8 +180,11 @@ async function analyzeSyntaxOfText(text) {
     type: 'PLAIN_TEXT',
   };
 
-  // Detects syntax in the document
-  const [syntax] = await client.analyzeSyntax({document});
+  // Need to specify an encodingType to receive word offsets
+  const encodingType = 'UTF-8';
+
+  // Detects the sentiment of the document
+  const [syntax] = await client.analyzeSentiment({document, encodingType});
 
   console.log('Tokens:');
   syntax.tokens.forEach(part => {
@@ -211,8 +214,11 @@ async function analyzeSyntaxInFile(bucketName, fileName) {
     type: 'PLAIN_TEXT',
   };
 
-  // Detects syntax in the document
-  const [syntax] = await client.analyzeSyntax({document});
+  // Need to specify an encodingType to receive word offsets
+  const encodingType = 'UTF-8';
+
+  // Detects the sentiment of the document
+  const [syntax] = await client.analyzeSentiment({document, encodingType});
 
   console.log('Parts of speech:');
   syntax.tokens.forEach(part => {


### PR DESCRIPTION
This adds the encodingType field to requests to the analyze-syntax method of the Natural Language API.

The pull request updates the following region tags:

- language_syntax_gcs
- language_syntax_text

Fixes #363  🦕
