### PR TITLE
chore: add api_shortname and library_type to repo metadata

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -13,5 +13,5 @@
   "api_id": "language.googleapis.com",
   "repo": "googleapis/nodejs-language",
   "api_shortname": "language",
-  "library_type": ""
+  "library_type": "GAPIC_AUTO"
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "default_version": "v1",
-  "release_level": "ga",
+  "release_level": "stable",
   "requires_billing": true,
   "client_documentation": "https://cloud.google.com/nodejs/docs/reference/language/latest",
   "codeowner_team": "@googleapis/ml-apis",
@@ -11,5 +11,7 @@
   "distribution_name": "@google-cloud/language",
   "name_pretty": "Natural Language",
   "api_id": "language.googleapis.com",
-  "repo": "googleapis/nodejs-language"
+  "repo": "googleapis/nodejs-language",
+  "api_shortname": "language",
+  "library_type": ""
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # [Natural Language: Node.js Client](https://github.com/googleapis/nodejs-language)
 
-[![release level](https://img.shields.io/badge/release%20level-general%20availability%20%28GA%29-brightgreen.svg?style=flat)](https://cloud.google.com/terms/launch-stages)
+
 [![npm version](https://img.shields.io/npm/v/@google-cloud/language.svg)](https://www.npmjs.org/package/@google-cloud/language)
 [![codecov](https://img.shields.io/codecov/c/github/googleapis/nodejs-language/main.svg?style=flat)](https://codecov.io/gh/googleapis/nodejs-language)
 
@@ -128,12 +128,6 @@ _Legacy Node.js versions are supported as a best effort:_
 
 This library follows [Semantic Versioning](http://semver.org/).
 
-
-This library is considered to be **General Availability (GA)**. This means it
-is stable; the code surface will not change in backwards-incompatible ways
-unless absolutely necessary (e.g. because of critical security issues) or with
-an extensive deprecation period. Issues and requests against **GA** libraries
-are addressed with the highest priority.
 
 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # [Natural Language: Node.js Client](https://github.com/googleapis/nodejs-language)
 
-
+[![release level](https://img.shields.io/badge/release%20level-stable-brightgreen.svg?style=flat)](https://cloud.google.com/terms/launch-stages)
 [![npm version](https://img.shields.io/npm/v/@google-cloud/language.svg)](https://www.npmjs.org/package/@google-cloud/language)
 
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,11 @@ This library follows [Semantic Versioning](http://semver.org/).
 
 
 
+This library is considered to be **stable**. The code surface will not change in backwards-incompatible ways
+unless absolutely necessary (e.g. because of critical security issues) or with
+an extensive deprecation period. Issues and requests against **stable** libraries
+are addressed with the highest priority.
+
 
 
 


### PR DESCRIPTION
Update .repo-metadata.json as required by go/library-data-integrity 